### PR TITLE
added previously disabled password confirmation label

### DIFF
--- a/app/views/mailboxes/edit.html.haml
+++ b/app/views/mailboxes/edit.html.haml
@@ -23,7 +23,7 @@
         %fieldset
           %legend Change Password
           = f.input :password, hint: 'Leave blank, if you do not want to change it.'
-          = f.input :password_confirmation, label: false
+          = f.input :password_confirmation
 
       = render partial: 'shared/mailbox_permissions'
 


### PR DESCRIPTION
Are there any good reasons why the label is disabled? Looks kind of weird to me